### PR TITLE
Add: connect front-end to backend

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import MyPage from "./pages/MyPage";
 import UserOrderDetailPage from "./pages/UserOrderDetailPage";
 import UserWishListPage from "./pages/UserWishListPage";
 import PublicWishListPage from "./pages/PublicWishListPage";
+import EmailConfirmationPage from "./pages/EmailConfirmationPage";
 
 const theme = createTheme({
   palette: {
@@ -65,6 +66,7 @@ function App() {
             <Route path="/shoppingcart" element={<ShoppingCartPage />} />
             <Route path="/checkout/success" element={<CheckoutSuccessPage />} />
             <Route path="/checkout/cancel" element={<CheckoutCancelPage />} />
+            <Route path="/email-confirmation/:uidb64/:token" element={<EmailConfirmationPage />} />
           </Routes>
         </Router>
       </div>

--- a/src/hook/useLogin.ts
+++ b/src/hook/useLogin.ts
@@ -73,13 +73,13 @@ const useLogin = () => {
     }
   };
 
-  const verifiyEmail = async (token: string) => {
+  const verifiyEmail = async (uidb64: string, token: string) => {
     try {
-      if (!token) {
-        throw new Error("token is necessary to verify.");
+      if (!uidb64 || !token) {
+        throw new Error("uidb64 and token are necessary to verify.");
       }
 
-      const data = await verifyEmailAPI(token);
+      const data = await verifyEmailAPI(uidb64, token);
       if (data?.error) {
         throw new Error(data.error);
       }
@@ -88,10 +88,14 @@ const useLogin = () => {
         throw new Error("Something wrong with login API");
       }
 
-      //認証成功時はユーザー情報をjotaiに入れる
-      setuserInfoJotai({ userInfo: data.user, authtoken: data.token });
-
-      alert("Verification Success!");
+      if (data?.message) {
+        alert(data.message); // メール認証成功メッセージを表示
+        alert("Verification Success!");
+        //home画面に移動
+        navigate("/");
+      } else {
+        throw new Error("Failed to confirm email.");
+      }
 
       //home画面に移動
       navigate("/");

--- a/src/lib/database/User.ts
+++ b/src/lib/database/User.ts
@@ -11,18 +11,18 @@ type ResponseFromAPI = {
 };
 
 export async function signUpAPI(
-  userName: string,
+  name: string,
   email: string,
   password: string,
 ) {
   try {
     // クエリパラメータを用意
-    const params: { [key: string]: unknown } = { userName, email, password };
-    if (!userName || !email || !password) {
-      throw new Error("userName, email and password are necessary.");
+    const params: { [key: string]: unknown } = { name, email, password };
+    if (!name || !email || !password) {
+      throw new Error("name, email and password are necessary.");
     }
     // データを送信する
-    const response = await apiClient.post("/user/register", params);
+    const response = await apiClient.post("/signup/", params);
     return response.data as ResponseFromAPI;
   } catch (error: unknown) {
     console.error("Error fetching data:", error);

--- a/src/lib/database/User.ts
+++ b/src/lib/database/User.ts
@@ -86,22 +86,41 @@ export async function checkLoginAPI(
   }
 }
 
-export async function verifyEmailAPI(token: string) {
+// export async function verifyEmailAPI(token: string) {
+//   try {
+//     // クエリパラメータを用意
+//     const params: { [key: string]: unknown } = { token };
+//     if (!token) {
+//       throw new Error("token is necessary.");
+//     }
+//     // データを送信する
+//     const response = await apiClient.post("/user/verify", params);
+//     return response.data as ResponseFromAPI;
+//   } catch (error: unknown) {
+//     console.error("Error fetching data:", error);
+//     if (isAxiosError(error)) {
+//       return error.response?.data;
+//     }
+
+//     return null;
+//   }
+// }
+export async function verifyEmailAPI(uidb64: string, token: string) {
   try {
-    // クエリパラメータを用意
-    const params: { [key: string]: unknown } = { token };
-    if (!token) {
-      throw new Error("token is necessary.");
+    if (!uidb64 || !token) {
+      throw new Error("uidb64 and token are necessary.");
     }
-    // データを送信する
-    const response = await apiClient.post("/user/verify", params);
-    return response.data as ResponseFromAPI;
+
+    // const params = { uidb64 };
+    const response = await apiClient.get(`/signup/account-confirm-email/${uidb64}/${token}/`);
+    console.log("API Response:", response.data); // レスポンスログ追加
+
+    return response.data; // メッセージを返す
   } catch (error: unknown) {
-    console.error("Error fetching data:", error);
+    console.error("Error verifying email:", error);
     if (isAxiosError(error)) {
       return error.response?.data;
     }
-
     return null;
   }
 }

--- a/src/lib/database/User.ts
+++ b/src/lib/database/User.ts
@@ -86,34 +86,13 @@ export async function checkLoginAPI(
   }
 }
 
-// export async function verifyEmailAPI(token: string) {
-//   try {
-//     // クエリパラメータを用意
-//     const params: { [key: string]: unknown } = { token };
-//     if (!token) {
-//       throw new Error("token is necessary.");
-//     }
-//     // データを送信する
-//     const response = await apiClient.post("/user/verify", params);
-//     return response.data as ResponseFromAPI;
-//   } catch (error: unknown) {
-//     console.error("Error fetching data:", error);
-//     if (isAxiosError(error)) {
-//       return error.response?.data;
-//     }
-
-//     return null;
-//   }
-// }
 export async function verifyEmailAPI(uidb64: string, token: string) {
   try {
     if (!uidb64 || !token) {
       throw new Error("uidb64 and token are necessary.");
     }
 
-    // const params = { uidb64 };
     const response = await apiClient.get(`/signup/account-confirm-email/${uidb64}/${token}/`);
-    console.log("API Response:", response.data); // レスポンスログ追加
 
     return response.data; // メッセージを返す
   } catch (error: unknown) {

--- a/src/pages/EmailConfirmationPage.tsx
+++ b/src/pages/EmailConfirmationPage.tsx
@@ -1,0 +1,45 @@
+import { useEffect } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { verifyEmailAPI } from "../lib/database/User";
+import Layout from "../component/shared/Layout";
+
+const EmailConfirmationPage = () => {
+  const { uidb64, token } = useParams<{ uidb64: string; token: string }>();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const verifyEmail = async () => {
+      if (!uidb64 || !token) {
+        alert("Invalid confirmation link.");
+        navigate("/");
+        return;
+      }
+
+      try {
+        const result = await verifyEmailAPI(uidb64, token);
+        if (result?.message) {
+          alert(result.message); // メール認証成功メッセージを表示
+          navigate("/"); // ホーム画面にリダイレクト
+        } else {
+          alert("Failed to confirm email.");
+          navigate("/"); // 失敗時もホーム画面に戻る
+        }
+      } catch (error) {
+        console.error(error);
+        alert("Error during email confirmation.");
+        navigate("/");
+      }
+    };
+    verifyEmail();
+  }, [uidb64, token, navigate]);
+
+  return (
+    <Layout>
+      <div style={{ textAlign: "center", padding: "20px" }}>
+        <h2>Processing Email Confirmation...</h2>
+      </div>
+    </Layout>
+  );
+};
+
+export default EmailConfirmationPage;


### PR DESCRIPTION
サインアップ機能、メール認証機能のフロント側とバックエンドの繋ぎ込みを実装します。
サインアップモーダルでSign Up押下→バックエンドのDBでユーザー登録され、メール認証(メールリンク押下)でis_activeが更新されるところまで確認済みです。
残対応：リンク押下時の遷移先をDjangoのBrowsable API画面→Home画面にする